### PR TITLE
Fix self.version and more logging + added gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+build/
+dist/
+.venv/
+.vscode/
+*.pyc
+*.spec


### PR DESCRIPTION
The version was not detected as a string, but as as a number.
Moreover some mods do not contain a exact "1.XX" version string, but rather "1.XX-Snapshot" or something. 
As long as the specified version "1.XX" is found somewhere, the mod will be downloaded.